### PR TITLE
Update radio_si446x.cpp

### DIFF
--- a/radio_si446x.cpp
+++ b/radio_si446x.cpp
@@ -77,6 +77,7 @@ void RadioSi446x::SendCmdReceiveAnswer(int byteCountTx, int byteCountRx, const c
     int reply = 0x00;
     while (reply != 0xFF)
     {       
+        SPI.transfer(0x44);  // added because CTS state is trasnmitted *after* issuing 0x44, not while.
        reply = SPI.transfer(0x44);
 //       Serial.print(reply,HEX);
 //       Serial.print(" ");


### PR DESCRIPTION
According to AN633 (https://www.silabs.com/Support%20Documents/TechnicalDocs/AN633.pdf, p.15 chapter 7.2.1.) the CTS state is reported vie SPI in the 8 SCLK cycles after issuing READ_CMD_BUFF (0x44). 
The value returned in parallel while issuing READ_CMD_BUFF is (at least in my case) not a valid CTS state. As the code interpreted the value returned in parallel as the CTS state, the reply loop, waiting for CTS=0xFF, never ended.
Fixed by inserting another SPI.transfer just before. Now each loop takes 16 SCLK cycles.
